### PR TITLE
Remove exception classes for empty tasks

### DIFF
--- a/src/main/java/him/BlankDeadlineException.java
+++ b/src/main/java/him/BlankDeadlineException.java
@@ -1,8 +1,0 @@
-package him;
-
-
-public class BlankDeadlineException extends Exception {
-    public BlankDeadlineException(String error) {
-        super(error);
-    }
-}

--- a/src/main/java/him/BlankEventException.java
+++ b/src/main/java/him/BlankEventException.java
@@ -1,8 +1,0 @@
-package him;
-
-
-public class BlankEventException extends Exception {
-    public BlankEventException(String error) {
-        super(error);
-    }
-}

--- a/src/main/java/him/BlankToDoException.java
+++ b/src/main/java/him/BlankToDoException.java
@@ -1,8 +1,0 @@
-package him;
-
-
-public class BlankToDoException extends Exception {
-    public BlankToDoException(String error) {
-        super(error);
-    }
-}

--- a/src/main/java/him/HimException.java
+++ b/src/main/java/him/HimException.java
@@ -1,8 +1,0 @@
-package him;
-
-
-public class HimException extends Exception {
-    public HimException(String msg) {
-        super(msg);
-    }
-}


### PR DESCRIPTION
Previously, we used dedicated exception classes to handle errors from tasks that are empty. Now, however, the exception handling logic has been moved into Him#getResponse(). Consequently, these exception classes are unused and only add clutter to the codebase.

Let's remove these classes to clean up the file/folder structure.